### PR TITLE
fix psgi.input

### DIFF
--- a/plack/app.psgi
+++ b/plack/app.psgi
@@ -14,7 +14,7 @@ return builder {
             return [
                 200,
                 ['Content-Type', 'application/octet-stream'],
-                [$req->body],
+                [$req->content],
             ]
         }
 

--- a/plack/handler.pl
+++ b/plack/handler.pl
@@ -11,12 +11,15 @@ my $app = require "$FindBin::Bin/app.psgi";
 sub handle {
     my ($payload) = @_;
 
+    my $body = $payload->{body};
+    open my $input, "<", \$body;
+
     my $resp = $app->(+{
         REQUEST_METHOD => $payload->{http_method},
         PATH_INFO => $payload->{path},
         QUERY_STRING => $payload->{query_string} || '',
-        'psgi.input' => $payload->{body},
-        CONTENT_LENGTH => bytes::length($payload->{body}) || 0,
+        'psgi.input' => $input,
+        CONTENT_LENGTH => bytes::length($body) || 0,
         CONTENT_TYPE => $payload->{content_type} || '',
     });
     use Data::Dumper; warn Dumper($resp); # TODO remove


### PR DESCRIPTION
psgi.input shoule be an IO::Handle-like object, not string.

> https://metacpan.org/pod/PSGI#The-Input-Stream
> The input stream in psgi.input is an IO::Handle-like object which streams the raw HTTP POST or PUT data. If it is a file handle then it MUST be opened in binary mode. The input stream MUST respond to read and MAY implement seek.